### PR TITLE
Switch annotations for sc2 and sc3 scores

### DIFF
--- a/run_challenge_workflow.cwl
+++ b/run_challenge_workflow.cwl
@@ -220,7 +220,7 @@ steps:
       - id: results
       
   switch_annotations:
-    run: score.cwl
+    run: switch_annotation.cwl
     in:
       - id: inputjson
         source: "#scoring/results"

--- a/run_challenge_workflow.cwl
+++ b/run_challenge_workflow.cwl
@@ -237,7 +237,7 @@ steps:
       - id: results
         source: "#switch_annotations/results"
       - id: private_annotations
-        default: ['sc2_joint_weighted_sum_rmse', 'sc2_hand_weighted_sum_rmse', 'sc2_foot_weighted_sum_rmse', 'sc3_joint_weighted_sum_rmse', 'sc3_hand_weighted_sum_rmse', 'sc3_foot_weighted_sum_rmse']
+        default: ['sc2_hand_weighted_sum_rmse', 'sc2_foot_weighted_sum_rmse', 'sc3_hand_weighted_sum_rmse', 'sc3_foot_weighted_sum_rmse']
     out: []
 
   annotate_submission_with_output:

--- a/run_challenge_workflow.cwl
+++ b/run_challenge_workflow.cwl
@@ -219,6 +219,14 @@ steps:
     out:
       - id: results
       
+  switch_annotations:
+    run: score.cwl
+    in:
+      - id: inputjson
+        source: "#scoring/results"
+    out:
+      - id: results
+
   score_email:
     run: https://raw.githubusercontent.com/Sage-Bionetworks/ChallengeWorkflowTemplates/synapse-docker/score_email.cwl
     in:
@@ -227,7 +235,7 @@ steps:
       - id: synapse_config
         source: "#synapseConfig"
       - id: results
-        source: "#scoring/results"
+        source: "#switch_annotations/results"
       - id: private_annotations
         default: ['sc2_joint_weighted_sum_rmse', 'sc2_hand_weighted_sum_rmse', 'sc2_foot_weighted_sum_rmse', 'sc3_joint_weighted_sum_rmse', 'sc3_hand_weighted_sum_rmse', 'sc3_foot_weighted_sum_rmse']
     out: []
@@ -238,7 +246,7 @@ steps:
       - id: submissionid
         source: "#submissionId"
       - id: annotation_values
-        source: "#scoring/results"
+        source: "#switch_annotations/results"
       - id: to_public
         default: true
       - id: force_change_annotation_acl

--- a/sbatch_singularity.cwl
+++ b/sbatch_singularity.cwl
@@ -127,7 +127,7 @@ requirements:
 
               # Format shell script
               shell_file = ['#!/bin/bash',
-                            '#SBATCH --partition=pascalnodes-medium',
+                            '#SBATCH --partition=pascalnodes',
                             '#SBATCH --job-name={submissionid}',
                             '#SBATCH --time=48:00:00',
                             '#SBATCH --mail-type=FAIL',

--- a/sbatch_singularity.cwl
+++ b/sbatch_singularity.cwl
@@ -129,7 +129,7 @@ requirements:
               shell_file = ['#!/bin/bash',
                             '#SBATCH --partition=pascalnodes',
                             '#SBATCH --job-name={submissionid}',
-                            '#SBATCH --time=48:00:00',
+                            '#SBATCH --time=12:00:00',
                             '#SBATCH --mail-type=FAIL',
                             '#SBATCH --mail-user=thomas.yu@sagebionetworks.org',
                             '#SBATCH --output={submissionid}_stdout.txt',

--- a/switch_annotation.cwl
+++ b/switch_annotation.cwl
@@ -4,7 +4,7 @@
 #
 cwlVersion: v1.0
 class: CommandLineTool
-baseCommand: python
+baseCommand: python3
 
 hints:
   DockerRequirement:
@@ -27,7 +27,7 @@ requirements:
     listing:
       - entryname: switch_annotation.py
         entry: |
-          #!/usr/bin/env python
+          #!/usr/bin/env python3
           import argparse
           import json
           parser = argparse.ArgumentParser()
@@ -36,7 +36,7 @@ requirements:
           args = parser.parse_args()
           
           with open(args.json, "r") as input:
-            result = json.load(f)
+            result = json.load(input)
 
           columns = ['sc2_total_weighted_sum_error', 'sc2_joint_weighted_sum_rmse', 
                      'sc3_hand_weighted_sum_rmse', 'sc3_total_weighted_sum_error',

--- a/switch_annotation.cwl
+++ b/switch_annotation.cwl
@@ -1,0 +1,65 @@
+#!/usr/bin/env cwl-runner
+#
+# Switches subchallenge 2 annotations with subchallenge 3 annotations
+#
+cwlVersion: v1.0
+class: CommandLineTool
+baseCommand: python
+
+hints:
+  DockerRequirement:
+    dockerPull: docker.synapse.org/syn18058986/synapsepythonclient:1.9.2
+
+inputs:
+  - id: inputjson
+    type: File
+
+arguments:
+  - valueFrom: switch_annotation.py
+  - valueFrom: $(inputs.inputjson.path)
+    prefix: -j
+  - valueFrom: results.json
+    prefix: -r
+
+requirements:
+  - class: InlineJavascriptRequirement
+  - class: InitialWorkDirRequirement
+    listing:
+      - entryname: switch_annotation.py
+        entry: |
+          #!/usr/bin/env python
+          import argparse
+          import json
+          parser = argparse.ArgumentParser()
+          parser.add_argument("-j", "--json", required=True, help="Json input to switch")
+          parser.add_argument("-r", "--results", required=True, help="Switched json")
+          args = parser.parse_args()
+          
+          with open(args.json, "r") as input:
+            result = json.load(f)
+
+          columns = ['sc2_total_weighted_sum_error', 'sc2_joint_weighted_sum_rmse', 
+                     'sc3_hand_weighted_sum_rmse', 'sc3_total_weighted_sum_error',
+                     'sc2_foot_weighted_sum_rmse', 'sc2_hand_weighted_sum_rmse',
+                     'sc3_joint_weighted_sum_rmse', 'sc3_foot_weighted_sum_rmse']
+          for col in columns:
+            if result[col] != 'NA':
+              result[col] = float(result[col])
+
+          new_score = {'sc3_total_weighted_sum_error': result['sc2_total_weighted_sum_error'],
+                      'sc3_joint_weighted_sum_rmse': result['sc2_joint_weighted_sum_rmse'],
+                      'sc2_hand_weighted_sum_rmse': result['sc3_hand_weighted_sum_rmse'],
+                      'sc2_total_weighted_sum_error': result['sc3_total_weighted_sum_error'],
+                      'sc3_foot_weighted_sum_rmse': result['sc2_foot_weighted_sum_rmse'],
+                      'sc3_hand_weighted_sum_rmse': result['sc2_hand_weighted_sum_rmse'],
+                      'sc2_joint_weighted_sum_rmse': result['sc3_joint_weighted_sum_rmse'],
+                      'sc2_foot_weighted_sum_rmse': result['sc3_foot_weighted_sum_rmse']}
+          result.update(new_score)
+          with open(args.results, 'w') as o:
+            o.write(json.dumps(result))
+     
+outputs:
+  - id: results
+    type: File
+    outputBinding:
+      glob: results.json


### PR DESCRIPTION
* switch annotations
* Use `pascalnodes` instead of `pascalnodes-medium` because less restrictive
* Add  joint scores into email.